### PR TITLE
Add OS support entries and tags

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,6 +12,21 @@
       "name": "puppetlabs-stdlib",
       "version_range": ">= 1.0.0"
     }
+  ],
+  "operatingsystem_support": [
+        {
+            "operatingsystem": "Solaris",
+            "operatingsystemrelease": [
+                "11",
+                "12"
+            ]
+        }
+    ],
+  "tags": [
+    "solaris",
+    "nameservice",
+    "dns",
+    "nis",
+    "ldap"
   ]
 }
-


### PR DESCRIPTION
Pulling in the differences from the metadata I made which has yet to be committed anywhere.